### PR TITLE
Use crypto:strong_rand_bytes

### DIFF
--- a/src/nklib_log_gelf.erl
+++ b/src/nklib_log_gelf.erl
@@ -111,12 +111,12 @@ message(_Id, Msg, #state{ip=Ip, port=Port, socket=Socket}=State) ->
             Gelf2 = nklib_json:encode(maps:from_list(lists:flatten(Gelf1))),
             case byte_size(Gelf2) of
                 Size when Size =< ?MAX_UDP ->
-                    % io:format("SENDING ~p ~p (~p) ~s\n", 
+                    % io:format("SENDING ~p ~p (~p) ~s\n",
                     %           [Ip, Port, byte_size(Gelf2), Gelf2]),
                     ok = gen_udp:send(Socket, Ip, Port, Gelf2);
                 Size ->
                     Chunks = get_num_chunks(Size),
-                    Id = crypto:rand_bytes(8),
+                    Id = crypto:strong_rand_bytes(8),
                     Head = <<30, 15, Id/binary>>,
                     send_chunks(Gelf2, Head, 0, Chunks, Socket, Ip, Port)
             end,

--- a/src/nklib_util.erl
+++ b/src/nklib_util.erl
@@ -144,7 +144,7 @@ safe_call(Dest, Msg, Timeout) ->
     Master = self(),
     Slave = spawn(
         fun() ->
-            Reply = try  
+            Reply = try
                 {ok, gen_server:call(Dest, Msg, Timeout)}
             catch
                 error:E -> {error, E};
@@ -153,7 +153,7 @@ safe_call(Dest, Msg, Timeout) ->
             Master ! {self(), Reply}
         end
     ),
-    receive 
+    receive
         {Slave, {ok, Msg}} -> Msg;
         {Slave, {error, Error}} -> error(Error);
         {Slave, {exit, Exit}} -> exit(Exit)
@@ -161,7 +161,7 @@ safe_call(Dest, Msg, Timeout) ->
 
 
 %% @doc Generates a new printable random UUID.
--spec luid() -> 
+-spec luid() ->
     binary().
 
 luid() ->
@@ -173,19 +173,19 @@ luid() ->
     binary().
 
 uuid_4122() ->
-    Rand = hex(crypto:rand_bytes(4)),
-    <<A:16/bitstring, B:16/bitstring, C:16/bitstring>> = 
+    Rand = hex(crypto:strong_rand_bytes(4)),
+    <<A:16/bitstring, B:16/bitstring, C:16/bitstring>> =
         <<(nklib_util:l_timestamp()):48>>,
     {ok, Hw} = application:get_env(nklib, hw_addr),
-    <<Rand/binary, $-, (hex(A))/binary, $-, (hex(B))/binary, $-, 
+    <<Rand/binary, $-, (hex(A))/binary, $-, (hex(B))/binary, $-,
       (hex(C))/binary, $-, Hw/binary>>.
 
 
 %% @doc Generates a new printable SHA hash binary over `Base' (using 160 bits, 27 chars).
--spec lhash(term()) -> 
+-spec lhash(term()) ->
     binary().
 
-lhash(Base) -> 
+lhash(Base) ->
     <<I:160/integer>> = sha(term_to_binary(Base)),
     case encode_integer(I) of
         Hash when byte_size(Hash) == 27 -> Hash;
@@ -202,14 +202,14 @@ sha(Term) -> crypto:hash(sha, Term).
 
 
 %% @doc Generates a new random tag of 6 chars
--spec uid() -> 
+-spec uid() ->
     binary().
 
 uid() ->
     hash({make_ref(), os:timestamp()}).
 
 %% @doc Generates a new tag of 6 chars based on a value.
--spec hash(term()) -> 
+-spec hash(term()) ->
     binary().
 
 hash(Base) ->
@@ -220,7 +220,7 @@ hash(Base) ->
 
 
 %% @doc Generates a new tag based on a value (only numbers and uppercase) of 7 chars
--spec hash36(term()) -> 
+-spec hash36(term()) ->
     binary().
 
 hash36(Base) ->
@@ -246,7 +246,7 @@ get_hwaddr() ->
         false ->
             case get_hwaddrs(Addrs1) of
                 {ok, Hex} -> Hex;
-                false -> hex(crypto:rand_bytes(6))
+                false -> hex(crypto:strong_rand_bytes(6))
             end
     end.
 
@@ -259,7 +259,7 @@ get_hwaddrs([{_Name, Data}|Rest]) ->
 
 get_hwaddrs([]) ->
     false.
-    
+
 
 % calendar:datetime_to_gregorian_seconds({{1970,1,1},{0,0,0}}).
 -define(SECONDS_FROM_GREGORIAN_BASE_TO_EPOCH, (1970*365+478)*24*60*60).
@@ -282,7 +282,7 @@ l_timestamp() ->
 
 
 %% @doc Converts a `timestamp()' to a local `datetime()'.
--spec timestamp_to_local(timestamp()) -> 
+-spec timestamp_to_local(timestamp()) ->
     calendar:datetime().
 
 timestamp_to_local(Secs) ->
@@ -290,14 +290,14 @@ timestamp_to_local(Secs) ->
 
 
 %% @doc Converts a `timestamp()' to a gmt `datetime()'.
--spec timestamp_to_gmt(timestamp()) -> 
+-spec timestamp_to_gmt(timestamp()) ->
     calendar:datetime().
 
 timestamp_to_gmt(Secs) ->
     calendar:now_to_universal_time({0, Secs, 0}).
 
 %% @doc Generates a float representing `HHMMSS.MicroSecs' for a high resolution timer.
--spec l_timestamp_to_float(l_timestamp()) -> 
+-spec l_timestamp_to_float(l_timestamp()) ->
     float().
 
 l_timestamp_to_float(LStamp) ->
@@ -308,7 +308,7 @@ l_timestamp_to_float(LStamp) ->
 
 
 %% @doc Converts a local `datetime()' to a `timestamp()',
--spec gmt_to_timestamp(calendar:datetime()) -> 
+-spec gmt_to_timestamp(calendar:datetime()) ->
     timestamp().
 
 gmt_to_timestamp(DateTime) ->
@@ -316,7 +316,7 @@ gmt_to_timestamp(DateTime) ->
 
 
 %% @doc Converts a gmt `datetime()' to a `timestamp()'.
--spec local_to_timestamp(calendar:datetime()) -> 
+-spec local_to_timestamp(calendar:datetime()) ->
     timestamp().
 
 local_to_timestamp(DateTime) ->
@@ -329,7 +329,7 @@ local_to_timestamp(DateTime) ->
 
 
 %% @doc Equivalent to `proplists:get_value/2' but faster.
--spec get_value(term(), list()) -> 
+-spec get_value(term(), list()) ->
     term().
 
 get_value(Key, List) ->
@@ -337,7 +337,7 @@ get_value(Key, List) ->
 
 
 %% @doc Requivalent to `proplists:get_value/3' but faster.
--spec get_value(term(), list(), term()) -> 
+-spec get_value(term(), list(), term()) ->
     term().
 
 get_value(Key, List, Default) ->
@@ -349,7 +349,7 @@ get_value(Key, List, Default) ->
 
 %% @doc Similar to `get_value(Key, List, <<>>)' but converting the result into
 %% a `binary()'.
--spec get_binary(term(), list()) -> 
+-spec get_binary(term(), list()) ->
     binary().
 
 get_binary(Key, List) ->
@@ -358,7 +358,7 @@ get_binary(Key, List) ->
 
 %% @doc Similar to `get_value(Key, List, Default)' but converting the result into
 %% a `binary()'.
--spec get_binary(term(), list(), term()) -> 
+-spec get_binary(term(), list(), term()) ->
     binary().
 
 get_binary(Key, List, Default) ->
@@ -366,7 +366,7 @@ get_binary(Key, List, Default) ->
 
 
 %% @doc Similar to `get_value(Key, List, [])' but converting the result into a `list()'.
--spec get_list(term(), list()) -> 
+-spec get_list(term(), list()) ->
     list().
 
 get_list(Key, List) ->
@@ -375,17 +375,17 @@ get_list(Key, List) ->
 
 %% @doc Similar to `get_value(Key, List, Default)' but converting the result
 %% into a `list()'.
--spec get_list(term(), list(), term()) -> 
+-spec get_list(term(), list(), term()) ->
     list().
 
 get_list(Key, List, Default) ->
     to_list(get_value(Key, List, Default)).
 
 
-%% @doc Similar to `get_value(Key, List, 0)' but converting the result into 
+%% @doc Similar to `get_value(Key, List, 0)' but converting the result into
 %% an `integer()' or `error'.
--spec get_integer(term(), list()) -> 
-    integer() | error. 
+-spec get_integer(term(), list()) ->
+    integer() | error.
 
 get_integer(Key, List) ->
     to_integer(get_value(Key, List, 0)).
@@ -393,14 +393,14 @@ get_integer(Key, List) ->
 
 %% @doc Similar to `get_value(Key, List, Default)' but converting the result into
 %% a `integer()' or `error'.
--spec get_integer(term(), list(), term()) -> 
+-spec get_integer(term(), list(), term()) ->
     integer() | error.
 
 get_integer(Key, List, Default) ->
     to_integer(get_value(Key, List, Default)).
 
 
-%% @doc Get the keys of a map or list (the first element of any tuple, 
+%% @doc Get the keys of a map or list (the first element of any tuple,
 %% or the element itself)
 -spec keys(map()|list()) ->
     [term()].
@@ -422,18 +422,18 @@ keys(List) when is_list(List) ->
 %% @doc Stores a value in a list
 -spec store_value(term(), list()) ->
     list().
- 
+
 store_value(Term, List) ->
     case lists:member(Term, List) of
         true -> List;
         false -> [Term|List]
     end.
 
-    
+
 %% @doc Stores a value in a proplist
 -spec store_value(term(), term(), nklib:optslist()) ->
     nklib:optslist().
- 
+
 store_value(Key, Val, List) ->
     lists:keystore(Key, 1, List, {Key, Val}).
 
@@ -441,7 +441,7 @@ store_value(Key, Val, List) ->
 %% @doc Stores a set of values in a proplist
 -spec store_values(list(), nklib:optslist()) ->
     nklib:optslist().
- 
+
 store_values([{Key, Val}|Rest], List) ->
     store_values(Rest, store_value(Key, Val, List));
 store_values([Val|Rest], List) ->
@@ -496,12 +496,12 @@ filtermap(F, [Hd|Tail]) ->
         false ->
             filtermap(F, Tail)
     end;
-filtermap(F, []) when is_function(F, 1) -> 
+filtermap(F, []) when is_function(F, 1) ->
     [].
 
 
 %% @doc Converts anything into a `binary()'. Can convert ip addresses also.
--spec to_binary(term()) -> 
+-spec to_binary(term()) ->
     binary().
 
 to_binary(B) when is_binary(B) -> B;
@@ -515,7 +515,7 @@ to_binary(N) -> msg("~p", [N]).
 
 
 %% @doc Converts anything into a `string()'.
--spec to_list(string()|binary()|atom()|integer()|pid()) -> 
+-spec to_list(string()|binary()|atom()|integer()|pid()) ->
     string().
 
 to_list(L) when is_list(L) -> L;
@@ -528,7 +528,7 @@ to_list(P) when is_pid(P) -> pid_to_list(P).
 
 %% @doc Converts anything into a `atom()'.
 %% WARNING: Can create new atoms
--spec to_atom(string()|binary()|atom()|integer()) -> 
+-spec to_atom(string()|binary()|atom()|integer()) ->
     atom().
 
 to_atom(A) when is_atom(A) -> A;
@@ -538,7 +538,7 @@ to_atom(I) when is_integer(I) -> list_to_atom(integer_to_list(I)).
 
 
 %% @doc Converts anything into an existing atom or throws an error
--spec to_existing_atom(string()|binary()|atom()|integer()) -> 
+-spec to_existing_atom(string()|binary()|atom()|integer()) ->
     atom().
 
 to_existing_atom(A) when is_atom(A) -> A;
@@ -547,12 +547,12 @@ to_existing_atom(L) when is_list(L) -> list_to_existing_atom(L);
 to_existing_atom(I) when is_integer(I) -> to_existing_atom(integer_to_list(I)).
 
 
--spec to_map(list()|map()) -> 
+-spec to_map(list()|map()) ->
     map().
 
-to_map(M) when is_map(M) -> 
+to_map(M) when is_map(M) ->
     M;
-to_map(L) when is_list(L) -> 
+to_map(L) when is_list(L) ->
     L1 = lists:map(
         fun(T) ->
             case T of
@@ -568,11 +568,11 @@ to_map(L) when is_list(L) ->
 -spec to_integer(integer()|binary()|string()) ->
     integer() | error.
 
-to_integer(I) when is_integer(I) -> 
+to_integer(I) when is_integer(I) ->
     I;
-to_integer(B) when is_binary(B) -> 
+to_integer(B) when is_binary(B) ->
     to_integer(binary_to_list(B));
-to_integer(L) when is_list(L) -> 
+to_integer(L) when is_list(L) ->
     case catch list_to_integer(L) of
         I when is_integer(I) -> I;
         _ -> error
@@ -605,7 +605,7 @@ to_boolean(Term) ->
 to_ip({A, B, C, D}) when is_integer(A), is_integer(B), is_integer(C), is_integer(D) ->
     {ok, {A, B, C, D}};
 
-to_ip({A, B, C, D, E, F, G, H}) when is_integer(A), is_integer(B), is_integer(C), 
+to_ip({A, B, C, D, E, F, G, H}) when is_integer(A), is_integer(B), is_integer(C),
                                      is_integer(D), is_integer(E), is_integer(F),
                                      is_integer(G), is_integer(H) ->
     {ok, {A, B, C, D, E, F, G, H}};
@@ -635,15 +635,15 @@ to_host(IpOrHost) ->
     to_host(IpOrHost, false).
 
 
-%% @doc Converts an IP or host to a binary host value. 
+%% @doc Converts an IP or host to a binary host value.
 % If `IsUri' and it is an IPv6 address, it will be enclosed in `[' and `]'
 -spec to_host(inet:ip_address() | string() | binary(), boolean()) ->
     binary().
 
-to_host({A,B,C,D}=Address, _IsUri) 
+to_host({A,B,C,D}=Address, _IsUri)
     when is_integer(A), is_integer(B), is_integer(C), is_integer(D) ->
     list_to_binary(inet_parse:ntoa(Address));
-to_host({A,B,C,D,E,F,G,H}=Address, IsUri) 
+to_host({A,B,C,D,E,F,G,H}=Address, IsUri)
     when is_integer(A), is_integer(B), is_integer(C), is_integer(D),
     is_integer(E), is_integer(F), is_integer(G), is_integer(H) ->
     case IsUri of
@@ -658,19 +658,19 @@ to_host(Host, _IsUri) ->
 -spec to_lower(string()|binary()|atom()) ->
     binary().
 
-to_lower(List) when is_list(List) -> 
+to_lower(List) when is_list(List) ->
     list_to_binary(string:to_lower(List));
-to_lower(Other) -> 
+to_lower(Other) ->
     to_lower(to_list(Other)).
 
 
 %% @doc converts a `string()' or `binary()' to an upper `binary()'.
 -spec to_upper(string()|binary()|atom()) ->
     binary().
-    
-to_upper(List) when is_list(List) -> 
+
+to_upper(List) when is_list(List) ->
     list_to_binary(string:to_upper(List));
-to_upper(Other) -> 
+to_upper(Other) ->
     to_upper(to_list(Other)).
 
 
@@ -700,17 +700,17 @@ strip(Rest) -> Rest.
 -spec unquote(list()|binary()) ->
     list().
 
-unquote(Bin) when is_binary(Bin) -> 
+unquote(Bin) when is_binary(Bin) ->
     unquote(binary_to_list(Bin));
 
-unquote(List) -> 
+unquote(List) ->
     case strip(List) of
-        [$"|Rest] -> 
+        [$"|Rest] ->
             case strip(lists:reverse(Rest)) of
                 [$"|Rest1] -> strip(lists:reverse(Rest1));
                 _ -> []
             end;
-        Other -> 
+        Other ->
             Other
     end.
 
@@ -735,24 +735,24 @@ encode_integer_36(Int) ->
 
 
 %% @private
--spec integer_to_list(integer(), integer(), string()) -> 
+-spec integer_to_list(integer(), integer(), string()) ->
     string().
 
 integer_to_list(I0, Base, R0) ->
     D = I0 rem Base,
     I1 = I0 div Base,
-    R1 = if 
+    R1 = if
         D >= 36 -> [D-36+$a|R0];
         D >= 10 -> [D-10+$A|R0];
         true -> [D+$0|R0]
     end,
-    if 
+    if
         I1 == 0 -> R1;
        true -> integer_to_list(I1, Base, R1)
     end.
 
 
-%% @doc Extracts all elements in `Proplist' having key `KeyOrKeys' or having key in 
+%% @doc Extracts all elements in `Proplist' having key `KeyOrKeys' or having key in
 %% `KeyOrKeys' if `KeyOrKeys' is a list.
 -spec extract([term()], term() | [term()]) ->
     [term()].
@@ -760,11 +760,11 @@ integer_to_list(I0, Base, R0) ->
 extract(PropList, KeyOrKeys) ->
     Fun = fun(Term) ->
         if
-            is_tuple(Term), is_list(KeyOrKeys) -> 
+            is_tuple(Term), is_list(KeyOrKeys) ->
                 lists:member(element(1, Term), KeyOrKeys);
             is_tuple(Term) ->
                 element(1, Term) == KeyOrKeys;
-            is_list(KeyOrKeys) -> 
+            is_list(KeyOrKeys) ->
                 lists:member(Term, KeyOrKeys);
             Term == KeyOrKeys ->
                 true;
@@ -775,7 +775,7 @@ extract(PropList, KeyOrKeys) ->
     lists:filter(Fun, PropList).
 
 
-%% @doc Deletes all elements in `Proplist' having key `KeyOrKeys' or having key in 
+%% @doc Deletes all elements in `Proplist' having key `KeyOrKeys' or having key in
 %% `KeyOrKeys' if `KeyOrKeys' is a list.
 -spec delete([term()], term() | [term()]) ->
     [term()].
@@ -783,11 +783,11 @@ extract(PropList, KeyOrKeys) ->
 delete(PropList, KeyOrKeys) ->
     Fun = fun(Term) ->
         if
-            is_tuple(Term), is_list(KeyOrKeys) -> 
+            is_tuple(Term), is_list(KeyOrKeys) ->
                 not lists:member(element(1, Term), KeyOrKeys);
             is_tuple(Term) ->
                 element(1, Term) /= KeyOrKeys;
-            is_list(KeyOrKeys) -> 
+            is_list(KeyOrKeys) ->
                 not lists:member(Term, KeyOrKeys);
             Term /= KeyOrKeys ->
                 true;
@@ -812,7 +812,7 @@ defaults(List, [{Key, Val}|Rest]) ->
 
 
 %% @doc Checks if `Term' is a `string()' or `[]'.
--spec is_string(Term::term()) -> 
+-spec is_string(Term::term()) ->
     boolean().
 
 is_string([]) -> true;
@@ -828,7 +828,7 @@ bjoin(List) ->
     bjoin(List, <<",">>).
 
 %% @doc Join each element in `List' into a `binary()', using the indicated `Separator'.
--spec bjoin(List::[term()], Separator::binary()) -> 
+-spec bjoin(List::[term()], Separator::binary()) ->
     binary().
 
 bjoin([], _J) ->
@@ -878,7 +878,7 @@ capitalize(Name) ->
     capitalize(nklib_util:to_binary(Name), true, <<>>).
 
 
-% @private 
+% @private
 capitalize(<<>>, _, Acc) ->
     Acc;
 
@@ -931,7 +931,7 @@ randomize(List) when is_list(List) ->
 
 
 %% @private
--spec hex(binary()|string()) -> 
+-spec hex(binary()|string()) ->
     binary().
 
 hex(B) when is_binary(B) -> hex(binary_to_list(B), []);
@@ -968,7 +968,7 @@ cancel_timer(Ref) when is_reference(Ref) ->
     case erlang:cancel_timer(Ref) of
         false ->
             receive {timeout, Ref, _} -> 0
-            after 0 -> false 
+            after 0 -> false
             end;
         RemainingTime ->
             RemainingTime
@@ -1001,15 +1001,15 @@ demonitor(_) ->
 
 
 %% @private
--spec msg(string(), [term()]) -> 
+-spec msg(string(), [term()]) ->
     binary().
 
 msg(Msg, Vars) ->
     case catch list_to_binary(io_lib:format(Msg, Vars)) of
-        {'EXIT', _} -> 
+        {'EXIT', _} ->
             lager:warning("MSG PARSE ERROR: ~p, ~p", [Msg, Vars]),
             <<"Msg parser error">>;
-        Result -> 
+        Result ->
             Result
     end.
 


### PR DESCRIPTION
Previously used `crypto:rand_bytes` was removed in Erlang/OTP 20. `crypto:strong_rand_bytes` is available since R17